### PR TITLE
Don't get confused by attempting to parse XML comments

### DIFF
--- a/lib/juniter/has_children.rb
+++ b/lib/juniter/has_children.rb
@@ -53,6 +53,8 @@ module Juniter
       end
 
       nodes.each do |node|
+        next if node.is_a?(Ox::Comment)
+
         if node.is_a?(String) || node.is_a?(Ox::CData)
           value = node.is_a?(String) ? node : node.value
           text_child = self.class.text_child

--- a/test/support/valid.xml
+++ b/test/support/valid.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="AllTheSuites" time="6.888" tests="2" failures="0" errors="1" disabled="0">
+  <!-- this is a valid XML comment -->
+  <!-- see https://www.tutorialspoint.com/xml/xml_comments.htm -->
   <testsuite name="Amalgamation" skipped="0" failures="0" errors="1" tests="2" assertions="1" time="6.18216699999175" skipped="0" failures="0" errors="1" tests="2" skipped="0" disabled="0" id="3" hostname="localhost" package="TestPackage" timestamp="2020-04-30T12:00:00.000Z05:00">
     <properties>
       <property name="prop" value="value" />


### PR DESCRIPTION
This fixes a `KeyError: key not found: "this is a valid XML comment` error caused by perfectly valid XML comments appearing in JUnit output.